### PR TITLE
Update OAuthSignatureMethod.php

### DIFF
--- a/code/OAuthSignatureMethod.php
+++ b/code/OAuthSignatureMethod.php
@@ -46,7 +46,7 @@ abstract class OAuthSignatureMethod {
     // Avoid a timing leak with a (hopefully) time insensitive compare
     $result = 0;
     for ($i = 0; $i < strlen($signature); $i++) {
-      $result |= ord($built{$i}) ^ ord($signature{$i});
+      $result |= ord($built[$i]) ^ ord($signature[$i]);
     }
 
     return $result == 0;


### PR DESCRIPTION
PHP 8: Array and string offset access syntax with curly braces is no longer supported, so this needs changing